### PR TITLE
Groupieを利用したitemの更新処理の修正

### DIFF
--- a/app/src/main/java/jp/kuaddo/tsuidezake/bindingadapters/ImageViewBindingAdapters.kt
+++ b/app/src/main/java/jp/kuaddo/tsuidezake/bindingadapters/ImageViewBindingAdapters.kt
@@ -1,6 +1,5 @@
 package jp.kuaddo.tsuidezake.bindingadapters
 
-import android.graphics.Bitmap
 import android.net.Uri
 import android.widget.ImageView
 import androidx.databinding.BindingAdapter
@@ -8,17 +7,11 @@ import androidx.databinding.BindingMethod
 import androidx.databinding.BindingMethods
 import jp.kuaddo.tsuidezake.util.GlideApp
 
-@BindingAdapter("url")
-fun ImageView.bindImageUrl(url: String?) =
-    url?.let { GlideApp.with(context).load(it).into(this) }
-
 @BindingAdapter("uri")
-fun ImageView.bindImageUrl(uri: Uri?) =
-    uri?.let { GlideApp.with(context).load(it).into(this) }
-
-@BindingAdapter("bitmap")
-fun ImageView.bindImageBitmap(bitmap: Bitmap?) =
-    bitmap?.let { setImageBitmap(bitmap) }
+fun ImageView.bindImageUri(uri: Uri?) {
+    if (uri == null) setImageDrawable(null)
+    else GlideApp.with(context).load(uri).into(this)
+}
 
 @Suppress("unused")
 @BindingMethods(

--- a/app/src/main/java/jp/kuaddo/tsuidezake/ui/want_to_drink/SakeCardItem.kt
+++ b/app/src/main/java/jp/kuaddo/tsuidezake/ui/want_to_drink/SakeCardItem.kt
@@ -6,11 +6,10 @@ import jp.kuaddo.tsuidezake.R
 import jp.kuaddo.tsuidezake.databinding.ItemSakeCardBinding
 import jp.kuaddo.tsuidezake.model.SakeDetail
 
-class SakeCardItem(
+data class SakeCardItem(
     private val sakeDetail: SakeDetail,
-    private val onClickItem: () -> Unit
-) : BindableItem<ItemSakeCardBinding>() {
-
+    private val onClickItem: (SakeDetail) -> Unit
+) : BindableItem<ItemSakeCardBinding>(sakeDetail.id.toLong()) {
     override fun initializeViewBinding(view: View): ItemSakeCardBinding =
         ItemSakeCardBinding.bind(view)
 
@@ -19,7 +18,7 @@ class SakeCardItem(
     override fun bind(viewBinding: ItemSakeCardBinding, position: Int) {
         viewBinding.name = sakeDetail.name
         viewBinding.imageUri = sakeDetail.imageUri
-        viewBinding.root.setOnClickListener { onClickItem() }
+        viewBinding.root.setOnClickListener { onClickItem(sakeDetail) }
         viewBinding.executePendingBindings()
     }
 

--- a/app/src/main/java/jp/kuaddo/tsuidezake/ui/want_to_drink/WantToDrinkFragment.kt
+++ b/app/src/main/java/jp/kuaddo/tsuidezake/ui/want_to_drink/WantToDrinkFragment.kt
@@ -27,7 +27,7 @@ class WantToDrinkFragment : DaggerFragment(R.layout.fragment_want_to_drink) {
 
     private val wantToDrinkViewModel: WantToDrinkViewModel by viewModels { viewModelFactory }
     private val binding: FragmentWantToDrinkBinding by dataBinding()
-    private val adapter = GroupAdapter<GroupieViewHolder>()
+    private val adapter = GroupAdapter<GroupieViewHolder>().apply { spanCount = 2 }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         binding.wantToDrinkViewModel = wantToDrinkViewModel
@@ -42,9 +42,10 @@ class WantToDrinkFragment : DaggerFragment(R.layout.fragment_want_to_drink) {
         wantToDrinkViewModel.groupedWishListWithMode
             .observeNonNull(viewLifecycleOwner) { (groupedWishList, isGrid) ->
                 adapter.update(getGroups(groupedWishList, isGrid))
-                adapter.spanCount = 2
-                binding.recyclerView.layoutManager = getLayoutManager(isGrid)
             }
+        wantToDrinkViewModel.isGridMode.observeNonNull(viewLifecycleOwner) { isGrid ->
+            binding.recyclerView.layoutManager = getLayoutManager(isGrid)
+        }
     }
 
     private fun getLayoutManager(isGrid: Boolean) = if (isGrid) {
@@ -69,9 +70,9 @@ class WantToDrinkFragment : DaggerFragment(R.layout.fragment_want_to_drink) {
         isGrid: Boolean
     ): BindableItem<out ViewDataBinding> {
         return if (isGrid) {
-            SakeCardItem(sakeDetail) { showDrinkDetailFragment(sakeDetail) }
+            SakeCardItem(sakeDetail, ::showDrinkDetailFragment)
         } else {
-            WantToDrinkLinearItem(sakeDetail) { showDrinkDetailFragment(sakeDetail) }
+            WantToDrinkLinearItem(sakeDetail, ::showDrinkDetailFragment)
         }
     }
 

--- a/app/src/main/java/jp/kuaddo/tsuidezake/ui/want_to_drink/WantToDrinkHeaderItem.kt
+++ b/app/src/main/java/jp/kuaddo/tsuidezake/ui/want_to_drink/WantToDrinkHeaderItem.kt
@@ -5,10 +5,9 @@ import com.xwray.groupie.viewbinding.BindableItem
 import jp.kuaddo.tsuidezake.R
 import jp.kuaddo.tsuidezake.databinding.ItemWantToDrinkHeaderBinding
 
-class WantToDrinkHeaderItem(
+data class WantToDrinkHeaderItem(
     private val areaName: String
-) : BindableItem<ItemWantToDrinkHeaderBinding>() {
-
+) : BindableItem<ItemWantToDrinkHeaderBinding>(areaName.hashCode().toLong()) {
     override fun initializeViewBinding(view: View): ItemWantToDrinkHeaderBinding =
         ItemWantToDrinkHeaderBinding.bind(view)
 

--- a/app/src/main/java/jp/kuaddo/tsuidezake/ui/want_to_drink/WantToDrinkLinearItem.kt
+++ b/app/src/main/java/jp/kuaddo/tsuidezake/ui/want_to_drink/WantToDrinkLinearItem.kt
@@ -6,11 +6,10 @@ import jp.kuaddo.tsuidezake.R
 import jp.kuaddo.tsuidezake.databinding.ItemWantToDrinkLinearBinding
 import jp.kuaddo.tsuidezake.model.SakeDetail
 
-class WantToDrinkLinearItem(
+data class WantToDrinkLinearItem(
     private val sakeDetail: SakeDetail,
-    private val onClickItem: () -> Unit
-) : BindableItem<ItemWantToDrinkLinearBinding>() {
-
+    private val onClickItem: (SakeDetail) -> Unit
+) : BindableItem<ItemWantToDrinkLinearBinding>(sakeDetail.id.toLong()) {
     override fun initializeViewBinding(view: View): ItemWantToDrinkLinearBinding =
         ItemWantToDrinkLinearBinding.bind(view)
 
@@ -19,7 +18,7 @@ class WantToDrinkLinearItem(
     override fun bind(viewBinding: ItemWantToDrinkLinearBinding, position: Int) {
         viewBinding.name = sakeDetail.name
         viewBinding.imageUri = sakeDetail.imageUri
-        viewBinding.root.setOnClickListener { onClickItem() }
+        viewBinding.root.setOnClickListener { onClickItem(sakeDetail) }
         viewBinding.executePendingBindings()
     }
 }

--- a/data/remote/src/main/java/jp/kuaddo/tsuidezake/data/remote/internal/TsuidezakeServiceImpl.kt
+++ b/data/remote/src/main/java/jp/kuaddo/tsuidezake/data/remote/internal/TsuidezakeServiceImpl.kt
@@ -42,6 +42,7 @@ internal class TsuidezakeServiceImpl @Inject constructor(
             apolloClient.query(WishListQuery()).toApiResponse { response ->
                 response.wishList
                     .map { it.fragments.sakeDetailFragment.toSakeDetail() }
+                    .sortedBy { it.id }
             }
         }
 


### PR DESCRIPTION
適切にidを渡しequals()をオーバーライドすることで、無駄なチラつきも削除することができた
close #75